### PR TITLE
Crash in app_inject::populate_devicelist() fixed

### DIFF
--- a/audio-router-gui/app_inject.cpp
+++ b/audio-router-gui/app_inject.cpp
@@ -101,8 +101,8 @@ void app_inject::populate_devicelist()
         PropVariantInit(&varName);
 
         // Get the endpoint's friendly-name property.
-		if (SUCCEEDED(pProps->GetValue(PKEY_Device_FriendlyName, &varName)))
-			this->device_names.push_back(varName.pwszVal);
+        if (SUCCEEDED(pProps->GetValue(PKEY_Device_FriendlyName, &varName)))
+            this->device_names.push_back(varName.pwszVal);
 
         CoTaskMemFree(pwszID);
         PropVariantClear(&varName);

--- a/audio-router-gui/app_inject.cpp
+++ b/audio-router-gui/app_inject.cpp
@@ -101,9 +101,8 @@ void app_inject::populate_devicelist()
         PropVariantInit(&varName);
 
         // Get the endpoint's friendly-name property.
-        pProps->GetValue(PKEY_Device_FriendlyName, &varName);
-
-        this->device_names.push_back(varName.pwszVal);
+		if (SUCCEEDED(pProps->GetValue(PKEY_Device_FriendlyName, &varName)))
+			this->device_names.push_back(varName.pwszVal);
 
         CoTaskMemFree(pwszID);
         PropVariantClear(&varName);


### PR DESCRIPTION
The application may crash on startup in app_inject::populate_devicelist() because `pProps->GetValue(PKEY_Device_FriendlyName, &varName)` may fail in some cases, which eventually leads to referencing `nullptr` that is `varName.pwszVal`. I've fixed this by adding a result check for `GetValue`.